### PR TITLE
Fix tailwind content paths

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,7 @@
-@tailwind base; 
-@tailwind components; 
-@tailwind utilities; 
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white text-black;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import "@/app/globals.css";
+import "./globals.css";
 
 export const metadata = { title: "Happy Birthday Vika" };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{tsx,ts}"],
+  content: [
+    "./src/**/*.{ts,tsx}",
+    "./*.{ts,tsx}",
+  ],
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- broaden Tailwind `content` glob to include root files
- add default body colors in `globals.css`

## Testing
- `npm install`
- `npm run build` *(fails: next not found without install)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a3f71f4832f896211aff980fb01